### PR TITLE
blkfront: the request should include the unaligned sector

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+trunk (unreleased)
+* fix reading non-page aligned sectors
+
 0.2.3 (5-Oct-2013):
 * add Travis continuous integration scripts.
 * use new Activations.after interface

--- a/lib/blkfront.ml
+++ b/lib/blkfront.ml
@@ -278,7 +278,8 @@ let read_single_request t r =
 		    { Req.gref; first_sector; last_sector }
 		  ) (Array.of_list rs) in
 		let id = Int64.of_int (List.hd rs) in
-		let req = Req.({ op=Some Read; handle=t.vdev; id; sector=r.start_sector; segs }) in
+                let sector = Int64.(add r.start_sector (of_int r.start_offset)) in
+		let req = Req.({ op=Some Read; handle=t.vdev; id; sector; segs }) in
 		lwt res = Lwt_ring.Front.push_request_and_wait t.t.client
                   (fun () -> Eventchn.notify h t.t.evtchn)
                   (Req.Proto_64.write_request req) in


### PR DESCRIPTION
This fixes non-page aligned reads.

Signed-off-by: David Scott dave.scott@eu.citrix.com
