### PR TITLE
Activations: use only the high-level ("after") interface

### DIFF
--- a/lib/blkback.ml
+++ b/lib/blkback.ml
@@ -54,7 +54,7 @@ let empty = Bigarray.Array1.create Bigarray.char Bigarray.c_layout 0
 
 module Make(A: S.ACTIVATIONS) = struct
 let service_thread t =
-  let rec loop_forever () =
+  let rec loop_forever after =
     (* For all the requests on the ring, build up a list of
        writable and readonly grants. We will map and unmap these
        as a batch. *)
@@ -158,9 +158,9 @@ let service_thread t =
       if notify then Eventchn.notify t.xe t.evtchn;
       return () in
 
-    lwt () = A.wait t.evtchn in
-    loop_forever () in
-  loop_forever ()
+    lwt next = A.after t.evtchn after in
+    loop_forever next in
+  loop_forever A.program_start
 
 let init xg xe domid ring_info wait ops =
   let evtchn = Eventchn.bind_interdomain xe domid ring_info.RingInfo.event_channel in

--- a/lib/s.ml
+++ b/lib/s.ml
@@ -31,27 +31,4 @@ val after: Eventchn.t -> event -> event Lwt.t
     next call to [after] will immediately unblock. If the system
     is suspended and then resumed, all event channel bindings are invalidated
     and this function will fail with Generation.Invalid *)
-
-(** {2 Low level interface} *)
-
-val wait : Eventchn.t -> unit Lwt.t
-(** [wait evtchn] is a cancellable thread that will wake up when
-    [evtchn] is notified. Cancel it if you are no longer interested in
-    waiting on [evtchn]. Note that if the notification is sent before
-    [wait] is called then the notification is lost. *)
-
-val run : Eventchn.handle -> unit
-(** [run ()] goes through the event mask and activate any events,
-    potentially spawning new threads. This function is called by
-    [Main.run]. Do not call it unless you know what you are doing. *)
-
-val resume : unit -> unit
-(** [resume] needs to be called after the unikernel is
-    resumed. However, this function is automatically called by
-    {!Sched.suspend}. Do NOT use it unless you know what you are
-    doing. *)
-
-val dump : unit -> unit
-(** [dump ()] prints internal state to the console for debugging *)
-
 end


### PR DESCRIPTION
The low-level ("wait") interface can potentially lose events.

Signed-off-by: David Scott dave.scott@eu.citrix.com
