### PR TITLE
Add a 'force_close' function to tear down a device

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+trunk (unreleased)
+* blkback: add 'force_close' to more forcibly tear down the device
+
 1.1.0 (30-Jan-2014):
 * blkback: functorise over Activations.
 * Depend on `xen-grant` and `xen-event` libraries rather than `xenctrl`.

--- a/lib/blkback.ml
+++ b/lib/blkback.ml
@@ -274,6 +274,11 @@ let request_close name (domid, devid) =
   lwt backend_path = mk_backend_path client name (domid,devid) in
   writev client (List.map (fun (k, v) -> backend_path ^ "/" ^ k, v) (Blkproto.State.to_assoc_list Blkproto.State.Closing))
 
+let force_close (domid, device) =
+  lwt client = make () in
+  lwt frontend_path = mk_frontend_path client (domid, device) in
+  write_one client (frontend_path ^ "/state") (Blkproto.State.to_string Blkproto.State.Closed) 
+
 let run (id: string) name (domid,devid) =
   lwt client = make () in
   let xg = Gnttab.interface_open () in


### PR DESCRIPTION
Signed-off-by: David Scott dave.scott@eu.citrix.com
