### PR TITLE
blkfront: use indirect segments if available

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -6,6 +6,7 @@ trunk (unreleased)
 * blkback: support indirect descriptors (i.e. large block sizes)
 * blkfront: if the 'connect' string is at all ambiguous, fail rather
   than risk using the wrong disk
+* blkfront: use indirect segments if available
 
 1.1.0 (30-Jan-2014):
 * blkback: functorise over Activations.


### PR DESCRIPTION
This allows us to send up to 512 segments per request. With direct requests the limit is 11, which is too small to get good performance.

It helps on ARM, but also on x86. These graphs are for Xen running under VirtualBox on x86_64 (which shows a bigger effect due to caching on the host):

![block_read](https://cloud.githubusercontent.com/assets/554131/4472720/c3d2f36a-494a-11e4-84fb-5f367b96fe25.png)
![block_write](https://cloud.githubusercontent.com/assets/554131/4472724/c792fc16-494a-11e4-8b3a-f5b5002deb7a.png)

The old code peaks at 11, which is the most segments you can get without indirect pages.
