### PR TITLE
Support io-page 1.3.0+

### DIFF
--- a/lib/blkback.ml
+++ b/lib/blkback.ml
@@ -146,7 +146,7 @@ let service_thread t stats =
             printf "FATAL: failed to map batch of %d grant references\n%!" (List.length grants);
             failwith "Failed to map grants" (* TODO: handle this error cleanly *)
           | Some x ->
-            let buf = Cstruct.of_bigarray (Gnttab.Local_mapping.to_buf x) in
+            let buf = Io_page.to_cstruct (Gnttab.Local_mapping.to_buf x) in
             let _ = List.fold_left (fun i gref -> Hashtbl.add grant_table (Int32.of_int gref.Gnttab.ref) (Cstruct.sub buf (4096 * i) 4096); i + 1) 0 grants in
             Some x
         end in

--- a/lib/blkfront.ml
+++ b/lib/blkfront.ml
@@ -486,12 +486,10 @@ let connect id =
 
 let id t = string_of_int t.vdev
 
-exception Buffer_is_not_page_aligned
-exception Buffer_is_more_than_one_page
+exception Buffer_not_exactly_one_page
 let to_iopage x =
-  if x.Cstruct.off <> 0 then raise Buffer_is_not_page_aligned;
-  if x.Cstruct.len > 4096 then raise Buffer_is_more_than_one_page;
-  x.Cstruct.buffer
+  if x.Cstruct.len <> 4096 then raise Buffer_not_exactly_one_page;
+  Io_page.of_cstruct_exn x
 
 let to_iopages x =
   try return (List.map to_iopage x)


### PR DESCRIPTION
Depends on https://github.com/mirage/io-page/pull/16

Notes:

- The previous code allowed buffers less than one page in length, but then discarded the length information. This would allow reading or writing over the end of a buffer if a short buffer was passed.

- The V1 API says "Each of [buffers] must be a whole number of sectors in length.", so this code shouldn't really be rejecting multi-page buffers. But that's for another bug report...