### PR TITLE
Add `make xen-build` to check the xen build via docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM unikernel/mirage
+RUN opam install --deps-only mirage-block-xen -y
+COPY build.sh /build.sh

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 all: build doc
 
 NAME=mirage-block-xen
+IMAGE=$(NAME)
 J=4
 
 include config.mk
@@ -38,6 +39,12 @@ test: setup.bin build
 reinstall: setup.bin
 	@ocamlfind remove $(NAME) || true
 	@./setup.bin -reinstall
+
+xen-depends: Dockerfile build.sh
+	docker build -t $(IMAGE) .
+
+xen-build: xen-depends clean
+	docker run -v $(shell pwd):/src $(IMAGE) /build.sh
 
 clean:
 	@ocamlbuild -clean

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+cd /src
+opam pin add mirage-block-xen . -y


### PR DESCRIPTION
This is useful for building the library on non-Linux platforms
like OS X.

Signed-off-by: David Scott <dave@recoil.org>