### PR TITLE
mirage-block-xen: depend on xenstore.client

### DIFF
--- a/lib/jbuild
+++ b/lib/jbuild
@@ -19,6 +19,6 @@
  ((name mirage_block_xen_back)
   (public_name mirage-block-xen.back)
   (modules (Blkback Block_request))
-  (libraries (logs lwt cstruct cstruct.ppx io-page shared-memory-ring shared-memory-ring-lwt mirage-block-xen xen-evtchn xen-gnt xenstore mirage-block-lwt rresult))
+  (libraries (logs lwt cstruct cstruct.ppx io-page shared-memory-ring shared-memory-ring-lwt mirage-block-xen xen-evtchn xen-gnt xenstore xenstore.client mirage-block-lwt rresult))
   (wrapped false)
 ))


### PR DESCRIPTION
Signed-off-by: David Scott <dave@recoil.org>