### PR TITLE
xen: blkfront needs io-page-xen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: c
-install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.travis-opam.sh
-script: bash -ex .travis-opam.sh
+sudo: false
+services:
+  - docker
+install: wget https://raw.githubusercontent.com/ocaml/ocaml-travisci-skeleton/master/.travis-docker.sh
+script: bash -ex ./.travis-docker.sh
 env:
   global:
-    - PACKAGE="mirage-block-xen"
-    - PINS="mirage-xen"
+  - PACKAGE="mirage-block-xen"
   matrix:
-  - OCAML_VERSION=4.04
-  - OCAML_VERSION=4.03
+  - DISTRO="ubuntu-16.04" OCAML_VERSION="4.03.0"
+  - DISTRO="alpine-3.5" OCAML_VERSION="4.04.0"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+## 1.5.3 (2016-06-16):
+* Add missing dependency on io-page-xen
+
 ## 1.5.2 (2017-06-11):
 
 * Add missing dependency on xenstore.client

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -11,7 +11,7 @@
  ((name mirage_block_xen_front)
   (public_name mirage-block-xen.front)
   (modules (Blkfront Block))
-  (libraries (logs stringext lwt cstruct cstruct.ppx mirage-block-lwt io-page shared-memory-ring shared-memory-ring-lwt mirage-block-xen xen-evtchn xen-gnt mirage-xen))
+  (libraries (logs stringext lwt cstruct cstruct.ppx mirage-block-lwt io-page io-page-xen shared-memory-ring shared-memory-ring-lwt mirage-block-xen xen-evtchn xen-gnt mirage-xen))
   (wrapped false)
 ))
 

--- a/mirage-block-xen.opam
+++ b/mirage-block-xen.opam
@@ -33,7 +33,7 @@ depends: [
   "shared-memory-ring-lwt"
   "mirage-block-lwt" {>= "1.0.0"}
   "ipaddr"
-  "io-page" {>= "1.4.0"}
+  "io-page-xen" {>= "2.0.0"}
   "mirage-xen" {>= "1.0.1" }
   "rresult"
 ]


### PR DESCRIPTION
Previously it would benefit from these bindings being automatically
linked via mirage-xen.

Related to mirage/mirage#836

Signed-off-by: David Scott <dave@recoil.org>