### PR TITLE
Use `ppx_cstruct` directly instead of the `cstruct.ppx` compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ env:
   - PACKAGE="mirage-block-xen"
   matrix:
   - DISTRO="ubuntu-16.04" OCAML_VERSION="4.03.0"
-  - DISTRO="alpine-3.5" OCAML_VERSION="4.04.0"
+  - DISTRO="alpine" OCAML_VERSION="4.04.2"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,8 @@
-## 1.5.3 (2016-06-16):
+## 1.5.4 (2017-07-05):
+* Use `ppx_cstruct` directly instead of the `cstruct.ppx` compat
+  package, which makes it easier for jbuilder subdirectory embedding.
+
+## 1.5.3 (2017-06-16):
 * Add missing dependency on io-page-xen
 
 ## 1.5.2 (2017-06-11):

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -2,16 +2,16 @@
  ((name mirage_block_xen)
   (public_name mirage-block-xen)
   (modules (Blkproto Device_number))
-  (libraries (cstruct cstruct.ppx io-page))
+  (libraries (cstruct io-page))
   (wrapped false)
-  (preprocess (pps (cstruct.ppx)))
+  (preprocess (pps (ppx_cstruct)))
 ))
 
 (library
  ((name mirage_block_xen_front)
   (public_name mirage-block-xen.front)
   (modules (Blkfront Block))
-  (libraries (logs stringext lwt cstruct cstruct.ppx mirage-block-lwt io-page io-page-xen shared-memory-ring shared-memory-ring-lwt mirage-block-xen xen-evtchn xen-gnt mirage-xen))
+  (libraries (logs stringext lwt cstruct ppx_cstruct mirage-block-lwt io-page io-page-xen shared-memory-ring shared-memory-ring-lwt mirage-block-xen xen-evtchn xen-gnt mirage-xen))
   (wrapped false)
 ))
 
@@ -19,6 +19,6 @@
  ((name mirage_block_xen_back)
   (public_name mirage-block-xen.back)
   (modules (Blkback Block_request))
-  (libraries (logs lwt cstruct cstruct.ppx io-page shared-memory-ring shared-memory-ring-lwt mirage-block-xen xen-evtchn xen-gnt xenstore xenstore.client mirage-block-lwt rresult))
+  (libraries (logs lwt cstruct ppx_cstruct io-page shared-memory-ring shared-memory-ring-lwt mirage-block-xen xen-evtchn xen-gnt xenstore xenstore.client mirage-block-lwt rresult))
   (wrapped false)
 ))


### PR DESCRIPTION
package, which makes it easier for jbuilder subdirectory embedding.