### PR TITLE
remove use of the OS module and directly depend on xenstore code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,6 @@ env:
   global:
   - PACKAGE="mirage-block-xen"
   matrix:
-  - DISTRO="ubuntu-16.04" OCAML_VERSION="4.03.0"
+  - DISTRO="ubuntu-16.04" OCAML_VERSION="4.05.0"
   - DISTRO="alpine" OCAML_VERSION="4.04.2"
+  - DISTRO="debian-stable" OCAML_VERSION="4.03.0"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+##
+* Remove usage of the OS module and directly depend on the Xenstore
+  code.
+
 ## 1.5.4 (2017-07-05):
 * Use `ppx_cstruct` directly instead of the `cstruct.ppx` compat
   package, which makes it easier for jbuilder subdirectory embedding.

--- a/lib/blkfront.ml
+++ b/lib/blkfront.ml
@@ -20,7 +20,7 @@ open Printf
 open Mirage_block
 open Blkproto
 open Gnt
-open OS
+open Mirage_xenstore_transport
 
 let src =
   let src = Logs.Src.create "blkfront" ~doc:"Mirage Xen blkfront" in

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -11,7 +11,7 @@
  ((name mirage_block_xen_front)
   (public_name mirage-block-xen.front)
   (modules (Blkfront Block))
-  (libraries (logs stringext lwt cstruct ppx_cstruct mirage-block-lwt io-page io-page-xen shared-memory-ring shared-memory-ring-lwt mirage-block-xen xen-evtchn xen-gnt mirage-xen))
+  (libraries (logs stringext lwt cstruct ppx_cstruct mirage-block-lwt io-page io-page-xen shared-memory-ring shared-memory-ring-lwt mirage-block-xen xen-evtchn xen-gnt mirage-xenstore-transport))
   (wrapped false)
 ))
 
@@ -22,3 +22,8 @@
   (libraries (logs lwt cstruct ppx_cstruct io-page shared-memory-ring shared-memory-ring-lwt mirage-block-xen xen-evtchn xen-gnt xenstore xenstore.client mirage-block-lwt rresult))
   (wrapped false)
 ))
+
+(alias
+  ((name mirage-xen)
+   (deps (mirage_block_xen.cmxa mirage_block_xen_back.cmxa mirage_block_xen_front.cmxa))
+   ))


### PR DESCRIPTION
This helps us migrate away from the magic OS module provided by
the mirage-xen/unix libraries.