### PR TITLE
Remove unused values

### DIFF
--- a/lib/blkproto.ml
+++ b/lib/blkproto.ml
@@ -15,8 +15,6 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  *)
 
-[@@@warning "-32"]
-
 type ('a, 'b) result = [
   | `OK of 'a
   | `Error of 'b

--- a/mirage-block-xen.opam
+++ b/mirage-block-xen.opam
@@ -14,6 +14,7 @@ depends: [
   "stringext"
   "lwt" {>= "2.4.3"}
   "cstruct" {>= "1.9.0"}
+  "ppx_cstruct" {build & >= "3.6.0"}
   "shared-memory-ring-lwt"
   "mirage-block-lwt" {>= "1.0.0"}
   "ipaddr"


### PR DESCRIPTION
Hi,

 "make" uses the dev profile with dune. It enables more warnings and detects some dead code. This also updates `ppx_cstruct` so that it does not emit warnings that need to be suppressed.

Let me know what you think. Thanks!