### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/mirage-block-xen.opam
+++ b/mirage-block-xen.opam
@@ -8,7 +8,7 @@ doc: "https://mirage.github.io/mirage-block-xen/"
 bug-reports: "https://github.com/mirage/mirage-block-xen/issues"
 depends: [
   "ocaml" {>= "4.02.0"}
-  "dune" {build}
+  "dune"
   "cmdliner"
   "logs"
   "stringext"


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.