### PR TITLE
Update to new Xen core platform stack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ env:
   global:
   - PACKAGE="mirage-block-xen"
   matrix:
-  - DISTRO="alpine" OCAML_VERSION="4.06"
-  - DISTRO="alpine" OCAML_VERSION="4.07"
-  - DISTRO="ubuntu" OCAML_VERSION="4.08"
+  - DISTRO="ubuntu" OCAML_VERSION="4.10"
+  - DISTRO="alpine" OCAML_VERSION="4.09"
+  - DISTRO="alpine" OCAML_VERSION="4.08"

--- a/lib/back/dune
+++ b/lib/back/dune
@@ -4,6 +4,6 @@
  (modules Blkback Block_request)
  (flags :standard -w -3)
  (libraries logs lwt cstruct io-page shared-memory-ring
-   shared-memory-ring-lwt mirage-block-xen xen-evtchn xenstore
+   shared-memory-ring-lwt mirage-block-xen xenstore
    xenstore.client mirage-block rresult mirage-xen)
  (wrapped false))

--- a/lib/front/dune
+++ b/lib/front/dune
@@ -3,6 +3,6 @@
  (public_name mirage-block-xen.front)
  (modules Blkfront Block)
  (libraries logs stringext lwt cstruct mirage-block io-page
-   io-page-xen shared-memory-ring shared-memory-ring-lwt mirage-block-xen
-   xen-evtchn mirage-xen)
+   shared-memory-ring shared-memory-ring-lwt mirage-block-xen
+   mirage-xen)
  (wrapped false))

--- a/mirage-block-xen.opam
+++ b/mirage-block-xen.opam
@@ -18,8 +18,8 @@ depends: [
   "shared-memory-ring-lwt"
   "mirage-block" {>= "2.0.0"}
   "ipaddr"
-  "io-page-xen" {>= "2.0.0"}
-  "mirage-xen" {>= "5.0.0"}
+  "io-page" {>= "2.0.0"}
+  "mirage-xen" {>= "6.0.0"}
   "rresult"
 ]
 build: [

--- a/mirage-block-xen.opam
+++ b/mirage-block-xen.opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/mirage/mirage-block-xen"
 doc: "https://mirage.github.io/mirage-block-xen/"
 bug-reports: "https://github.com/mirage/mirage-block-xen/issues"
 depends: [
-  "ocaml" {>= "4.06.0"}
+  "ocaml" {>= "4.08.0"}
   "dune"
   "cmdliner"
   "logs"


### PR DESCRIPTION
Update mirage-block-xen to the interface changes in the new Xen core
platform stack.

Part of mirage/mirage#1159, depends on mirage/mirage-xen#23.