### PR TITLE
adapt to cstruct 6.0.0 and fmt 0.8.7 API

### DIFF
--- a/lib/back/blkback.ml
+++ b/lib/back/blkback.ml
@@ -105,8 +105,8 @@ module Make(A: ACTIVATIONS)(X: Xs_client_lwt.S)(B: Mirage_block.S) = struct
 
 module BlockError = struct
   open Lwt
-  let fail_read e  = Fmt.kstrf fail_with "%a" B.pp_error e
-  let fail_write e = Fmt.kstrf fail_with "%a" B.pp_write_error e
+  let fail_read e  = Fmt.kstr fail_with "%a" B.pp_error e
+  let fail_write e = Fmt.kstr fail_with "%a" B.pp_write_error e
 end
 
 let service_thread t stats =

--- a/mirage-block-xen.opam
+++ b/mirage-block-xen.opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "1.0"}
   "logs"
   "lwt" {>= "2.4.3"}
-  "cstruct" {>= "1.9.0"}
+  "cstruct" {>= "6.0.0"}
   "ppx_cstruct" {>= "3.6.0"}
   "shared-memory-ring"
   "shared-memory-ring-lwt"
@@ -19,6 +19,7 @@ depends: [
   "io-page" {>= "2.0.0"}
   "mirage-xen" {>= "7.0.0"}
   "xenstore"
+  "fmt" {>= "0.8.7"}
 ]
 build: [
   ["dune" "subst"] {dev}


### PR DESCRIPTION
when https://github.com/ocaml/opam-repository/pull/21198 is merged, this will be important.